### PR TITLE
Add last_territory_count to the Turn output

### DIFF
--- a/environment/core/Halite.cpp
+++ b/environment/core/Halite.cpp
@@ -328,7 +328,7 @@ GameStatistics Halite::runGame(std::vector<std::string> * names_, unsigned int s
     while(std::count(result.begin(), result.end(), true) > 1 && turn_number < maxTurnNumber) {
         //Increment turn number:
         turn_number++;
-        if(!quiet_output) std::cout << "Turn " << turn_number << "\n";
+        if(!quiet_output) std::cout << "Turn " << turn_number << " ";
         //Frame logic.
         std::vector<bool> newResult = processNextFrame(result);
         //Add to vector of players that should be dead.
@@ -342,6 +342,13 @@ GameStatistics Halite::runGame(std::vector<std::string> * names_, unsigned int s
             return last_territory_count[u1] < last_territory_count[u2];
         });
         for(auto a = newRankings.begin(); a != newRankings.end(); a++) rankings.push_back(*a);
+        if (!quiet_output) {
+            std::cout << "Territory: ";
+            for(unsigned char a = 0; a < number_of_players; a++) {
+                std::cout << last_territory_count[a] << " ";
+            }
+            std::cout << std::endl;
+        }
         result = newResult;
     }
     std::vector<unsigned int> newRankings;


### PR DESCRIPTION
When generating slow games provide a little bit of entertainment for
those that might be watching.

Init Message received from player 6, randombox_v3.
Turn 1
Turn 2
Turn 3
Turn 4
Turn 5
Turn 6
Turn 7
Turn 8
Turn 9
Turn 10
..

Init Message received from player 6, randombox_v3.
Turn 1 Territory: 2 2 2 2 2 1 
Turn 2 Territory: 3 3 3 3 2 2 
Turn 3 Territory: 3 3 3 3 2 2 
Turn 4 Territory: 3 3 3 4 2 2 
Turn 5 Territory: 3 3 3 4 3 2 
Turn 6 Territory: 4 3 4 4 3 3 
Turn 7 Territory: 4 3 4 4 3 3 
Turn 8 Territory: 4 3 4 5 3 3 
Turn 9 Territory: 4 4 4 5 4 4 
Turn 10 Territory: 5 4 5 5 4 4
...