### PR TITLE
Add socket networking support for debugging

### DIFF
--- a/airesources/Python/hlt.py
+++ b/airesources/Python/hlt.py
@@ -1,7 +1,7 @@
 import sys
 from collections import namedtuple
 from itertools import chain, zip_longest
-
+import socket
 
 def grouper(iterable, n, fillvalue=None):
     "Collect data into fixed-length chunks or blocks"
@@ -81,18 +81,42 @@ class GameMap:
 # Functions for communicating with the Halite game environment  #
 #################################################################
 
+_socket_networking = False
+_connection = None
 
 def send_string(s):
-    sys.stdout.write(s)
-    sys.stdout.write('\n')
-    sys.stdout.flush()
-
+    s += '\n'
+    if _socket_networking:
+        _connection.sendall(bytes(s, 'ascii'))
+    else:
+        sys.stdout.write(s)
+        sys.stdout.flush()
 
 def get_string():
-    return sys.stdin.readline().rstrip('\n')
+    if _socket_networking:
+        newString = ""
+        buffer = '\0'
+        while True:
+            buffer = _connection.recv(1).decode('ascii')
+            if buffer != '\n':
+                newString += str(buffer)
+            else:
+                return newString
+    else:
+        return sys.stdin.readline().rstrip('\n')
 
-
-def get_init():
+def get_init(socket_networking=False):
+    global _socket_networking
+    _socket_networking = socket_networking
+    
+    if _socket_networking:
+        # Connect to environment.
+        global _connection
+        _connection = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        port = int(input('Enter the port on which to connect: '))
+        _connection.connect(('localhost', port))
+        print('Connected to intermediary on port #' + str(port))
+    
     playerID = int(get_string())
     m = GameMap(get_string(), get_string())
     return playerID, m


### PR DESCRIPTION
This PR attempts to add support for socket networking (to be able to debug bot within a running Halite environment) by integrating the relevant pieces of the socket_networing.py file provided by the Halite team in [this thread](http://forums.halite.io/t/running-your-halite-bot-from-an-ide/70).

It is enabled by passing socket_networking=True as a parameter to get_init.

I'm relatively new to Python and couldn't think of a better place for the _connection variable and the _socket_networking flag, but any feedback is appreciated.